### PR TITLE
fix: add fee zero adjustments to sign/place order examples

### DIFF
--- a/content/tutorial/01-simple-orders/01-order/03-sign-order/README.md
+++ b/content/tutorial/01-simple-orders/01-order/03-sign-order/README.md
@@ -20,7 +20,6 @@ For signing, we will use the `UnsignedOrder` type from the `SDK`, along with the
 /// file: run.ts
 import type { Web3Provider } from '@ethersproject/providers';
 +++import { OrderBookApi, SupportedChainId, OrderQuoteRequest, OrderQuoteSideKindSell, OrderSigningUtils, UnsignedOrder } from '@cowprotocol/cow-sdk';+++
-+++import { BigNumber } from 'ethers';+++
 
 
     
@@ -28,12 +27,18 @@ import type { Web3Provider } from '@ethersproject/providers';
 export async function run(provider: Web3Provider): Promise<unknown> {
   // ...
 
-  const order: UnsignedOrder = {
-    ...quote,
-    sellAmount: BigNumber.from(quote.sellAmount).add(BigNumber.from(quote.feeAmount)).toString(), // Quoted sellAmount must be added to quoted feeAmount
-    feeAmount: '0', // and feeAmount must be set to 0
-    receiver: ownerAddress, // required due type mismatch
-  }
+    // Use the original sellAmount, which is equal to quoted sellAmount added to quoted feeAmount
+    // sellAmount === BigNumber.from(quote.sellAmount).add(BigNumber.from(quote.feeAmount)).toString()
+
+    // And feeAmount must be set to 0
+    const feeAmount = '0'
+
+    const order: UnsignedOrder = {
+      ...quote,
+      sellAmount,
+      feeAmount,
+      receiver: ownerAddress,
+    }
 }
 ```
 

--- a/content/tutorial/01-simple-orders/01-order/03-sign-order/README.md
+++ b/content/tutorial/01-simple-orders/01-order/03-sign-order/README.md
@@ -20,12 +20,18 @@ For signing, we will use the `UnsignedOrder` type from the `SDK`, along with the
 /// file: run.ts
 import type { Web3Provider } from '@ethersproject/providers';
 +++import { OrderBookApi, SupportedChainId, OrderQuoteRequest, OrderQuoteSideKindSell, OrderSigningUtils, UnsignedOrder } from '@cowprotocol/cow-sdk';+++
++++import { BigNumber } from 'ethers';+++
+
+
+    
 
 export async function run(provider: Web3Provider): Promise<unknown> {
   // ...
 
   const order: UnsignedOrder = {
     ...quote,
+    sellAmount: BigNumber.from(quote.sellAmount).add(BigNumber.from(quote.feeAmount)).toString(), // Quoted sellAmount must be added to quoted feeAmount
+    feeAmount: '0', // and feeAmount must be set to 0
     receiver: ownerAddress, // required due type mismatch
   }
 }

--- a/content/tutorial/01-simple-orders/01-order/03-sign-order/app-b/src/lib/run.ts
+++ b/content/tutorial/01-simple-orders/01-order/03-sign-order/app-b/src/lib/run.ts
@@ -1,6 +1,5 @@
 import { OrderBookApi, OrderQuoteRequest, OrderQuoteSideKindSell, OrderSigningUtils, SupportedChainId, UnsignedOrder } from '@cowprotocol/cow-sdk';
 import type { Web3Provider } from '@ethersproject/providers';
-import { BigNumber } from 'ethers';
 
 export async function run(provider: Web3Provider): Promise<unknown> {
     const chainId = +(await provider.send('eth_chainId', []));
@@ -28,12 +27,16 @@ export async function run(provider: Web3Provider): Promise<unknown> {
 
     const { quote } = await orderBookApi.getQuote(quoteRequest);
 
-    // Quoted sellAmount must be added to quoted feeAmount, and feeAmount must be set to 0
+    // Use the original sellAmount, which is equal to quoted sellAmount added to quoted feeAmount
+    // sellAmount === BigNumber.from(quote.sellAmount).add(BigNumber.from(quote.feeAmount)).toString()
+
+    // And feeAmount must be set to 0
+    const feeAmount = '0'
 
     const order: UnsignedOrder = {
       ...quote,
-      sellAmount: BigNumber.from(quote.sellAmount).add(BigNumber.from(quote.feeAmount)).toString(),
-      feeAmount: '0',
+      sellAmount,
+      feeAmount,
       receiver: ownerAddress,
     }
 

--- a/content/tutorial/01-simple-orders/01-order/03-sign-order/app-b/src/lib/run.ts
+++ b/content/tutorial/01-simple-orders/01-order/03-sign-order/app-b/src/lib/run.ts
@@ -1,5 +1,6 @@
-import type { Web3Provider } from '@ethersproject/providers'
-import { OrderBookApi, SupportedChainId, OrderQuoteRequest, OrderQuoteSideKindSell, OrderSigningUtils, UnsignedOrder } from '@cowprotocol/cow-sdk'
+import { OrderBookApi, OrderQuoteRequest, OrderQuoteSideKindSell, OrderSigningUtils, SupportedChainId, UnsignedOrder } from '@cowprotocol/cow-sdk';
+import type { Web3Provider } from '@ethersproject/providers';
+import { BigNumber } from 'ethers';
 
 export async function run(provider: Web3Provider): Promise<unknown> {
     const chainId = +(await provider.send('eth_chainId', []));
@@ -27,8 +28,12 @@ export async function run(provider: Web3Provider): Promise<unknown> {
 
     const { quote } = await orderBookApi.getQuote(quoteRequest);
 
+    // Quoted sellAmount must be added to quoted feeAmount, and feeAmount must be set to 0
+
     const order: UnsignedOrder = {
       ...quote,
+      sellAmount: BigNumber.from(quote.sellAmount).add(BigNumber.from(quote.feeAmount)).toString(),
+      feeAmount: '0',
       receiver: ownerAddress,
     }
 

--- a/content/tutorial/01-simple-orders/01-order/04-submit-order/README.md
+++ b/content/tutorial/01-simple-orders/01-order/04-submit-order/README.md
@@ -20,6 +20,8 @@ export async function run(provider: Web3Provider): Promise<unknown> {
         const orderId = await orderBookApi.sendOrder({
             ...quote,
             ...orderSigningResult,
+            sellAmount: order.sellAmount, // replace quote sellAmount with signed order sellAmount
+            feeAmount: order.feeAmount, // replace quote feeAmount with signed order feeAmount
             signingScheme: orderSigningResult.signingScheme as unknown as SigningScheme
         })
   

--- a/content/tutorial/01-simple-orders/01-order/04-submit-order/README.md
+++ b/content/tutorial/01-simple-orders/01-order/04-submit-order/README.md
@@ -20,8 +20,8 @@ export async function run(provider: Web3Provider): Promise<unknown> {
         const orderId = await orderBookApi.sendOrder({
             ...quote,
             ...orderSigningResult,
-            sellAmount: order.sellAmount, // replace quote sellAmount with signed order sellAmount
-            feeAmount: order.feeAmount, // replace quote feeAmount with signed order feeAmount
+            sellAmount: order.sellAmount, // replace quote sellAmount with signed order sellAmount, which is equal to original sellAmount
+            feeAmount: order.feeAmount, // replace quote feeAmount with signed order feeAmount, which is 0
             signingScheme: orderSigningResult.signingScheme as unknown as SigningScheme
         })
   

--- a/content/tutorial/01-simple-orders/01-order/04-submit-order/app-a/src/lib/run.ts
+++ b/content/tutorial/01-simple-orders/01-order/04-submit-order/app-a/src/lib/run.ts
@@ -1,6 +1,5 @@
 import { OrderBookApi, OrderQuoteRequest, OrderQuoteSideKindSell, OrderSigningUtils, SupportedChainId, UnsignedOrder } from '@cowprotocol/cow-sdk';
 import type { Web3Provider } from '@ethersproject/providers';
-import { BigNumber } from 'ethers';
 
 export async function run(provider: Web3Provider): Promise<unknown> {
     const chainId = +(await provider.send('eth_chainId', []));
@@ -28,12 +27,16 @@ export async function run(provider: Web3Provider): Promise<unknown> {
 
     const { quote } = await orderBookApi.getQuote(quoteRequest);
 
-    // Quoted sellAmount must be added to quoted feeAmount, and feeAmount must be set to 0
+    // Use the original sellAmount, which is equal to quoted sellAmount added to quoted feeAmount
+    // sellAmount === BigNumber.from(quote.sellAmount).add(BigNumber.from(quote.feeAmount)).toString()
+
+    // And feeAmount must be set to 0
+    const feeAmount = '0'
 
     const order: UnsignedOrder = {
       ...quote,
-      sellAmount: BigNumber.from(quote.sellAmount).add(BigNumber.from(quote.feeAmount)).toString(),
-      feeAmount: '0',
+      sellAmount,
+      feeAmount,
       receiver: ownerAddress,
     }
 

--- a/content/tutorial/01-simple-orders/01-order/04-submit-order/app-a/src/lib/run.ts
+++ b/content/tutorial/01-simple-orders/01-order/04-submit-order/app-a/src/lib/run.ts
@@ -1,5 +1,6 @@
-import type { Web3Provider } from '@ethersproject/providers'
-import { OrderBookApi, SupportedChainId, OrderQuoteRequest, OrderQuoteSideKindSell, OrderSigningUtils, UnsignedOrder } from '@cowprotocol/cow-sdk'
+import { OrderBookApi, OrderQuoteRequest, OrderQuoteSideKindSell, OrderSigningUtils, SupportedChainId, UnsignedOrder } from '@cowprotocol/cow-sdk';
+import type { Web3Provider } from '@ethersproject/providers';
+import { BigNumber } from 'ethers';
 
 export async function run(provider: Web3Provider): Promise<unknown> {
     const chainId = +(await provider.send('eth_chainId', []));
@@ -27,8 +28,12 @@ export async function run(provider: Web3Provider): Promise<unknown> {
 
     const { quote } = await orderBookApi.getQuote(quoteRequest);
 
+    // Quoted sellAmount must be added to quoted feeAmount, and feeAmount must be set to 0
+
     const order: UnsignedOrder = {
       ...quote,
+      sellAmount: BigNumber.from(quote.sellAmount).add(BigNumber.from(quote.feeAmount)).toString(),
+      feeAmount: '0',
       receiver: ownerAddress,
     }
 

--- a/content/tutorial/01-simple-orders/01-order/04-submit-order/app-b/src/lib/run.ts
+++ b/content/tutorial/01-simple-orders/01-order/04-submit-order/app-b/src/lib/run.ts
@@ -1,6 +1,5 @@
 import { OrderBookApi, OrderQuoteRequest, OrderQuoteSideKindSell, OrderSigningUtils, SigningScheme, SupportedChainId, UnsignedOrder } from '@cowprotocol/cow-sdk';
 import type { Web3Provider } from '@ethersproject/providers';
-import { BigNumber } from 'ethers';
 
 export async function run(provider: Web3Provider): Promise<unknown> {
     const chainId = +(await provider.send('eth_chainId', []));
@@ -28,12 +27,16 @@ export async function run(provider: Web3Provider): Promise<unknown> {
 
     const { quote } = await orderBookApi.getQuote(quoteRequest);
 
-    // Quoted sellAmount must be added to quoted feeAmount, and feeAmount must be set to 0
+    // Use the original sellAmount, which is equal to quoted sellAmount added to quoted feeAmount
+    // sellAmount === BigNumber.from(quote.sellAmount).add(BigNumber.from(quote.feeAmount)).toString()
+
+    // And feeAmount must be set to 0
+    const feeAmount = '0'
 
     const order: UnsignedOrder = {
       ...quote,
-      sellAmount: BigNumber.from(quote.sellAmount).add(BigNumber.from(quote.feeAmount)).toString(),
-      feeAmount: '0',
+      sellAmount,
+      feeAmount,
       receiver: ownerAddress,
     }
 
@@ -43,8 +46,8 @@ export async function run(provider: Web3Provider): Promise<unknown> {
         const orderId = await orderBookApi.sendOrder({
             ...quote,
             ...orderSigningResult,
-            sellAmount: order.sellAmount, // replace quote sellAmount with signed order sellAmount
-            feeAmount: order.feeAmount, // replace quote feeAmount with signed order feeAmount
+            sellAmount: order.sellAmount, // replace quote sellAmount with signed order sellAmount, which is equal to original sellAmount
+            feeAmount: order.feeAmount, // replace quote feeAmount with signed order feeAmount, which is 0
             signingScheme: orderSigningResult.signingScheme as unknown as SigningScheme
         })
     


### PR DESCRIPTION
# Description

Users are confused due to fee-zero changes.

The sign/order placement tutorial no longer works, as the feeAmount must be set to `0`.

# Changes

- [ ] Update signing order tutorial https://learn-git-fix-fee-zero-cowswap.vercel.app/tutorial/sign-order
- [ ] Update placing order tutorial https://learn-git-fix-fee-zero-cowswap.vercel.app/tutorial/submit-order

# Testing

Make sure shared test steps work.