### PR TITLE
hotfix: fix dev server startup command on WebContainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,5 @@
 		"prismjs": "^1.29.0",
 		"ws": "^8.13.0",
 		"yootils": "^0.3.1"
-	},
-	"packageManager": "pnpm@7.27.0"
+	}
 }

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -134,7 +134,7 @@ export async function create(base, error, progress, logs, warnings) {
 			await run_dev();
 
 			async function run_dev() {
-				const process = await vm.spawn('turbo', ['run', 'dev']);
+				const process = await vm.spawn('yarn', ['dev']);
 
 				// TODO differentiate between stdout and stderr (sets `vite_error` to `true`)
 				// https://github.com/stackblitz/webcontainer-core/issues/971


### PR DESCRIPTION
# Description

Fixes #
1 - This PR makes adjustments to the server startup.
The server gets stuck on "starting server."
2 - This PR also removes the rule for using the pnpm package manager, since the project is using yarn.

<img width="1493" height="859" alt="Screenshot 2025-08-05 at 20 19 11" src="https://github.com/user-attachments/assets/e177b290-7f69-4cf0-a372-4f96a8b37dd7" />

