### PR TITLE
feat: add tutorial redirects and noindex headers in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,72 @@
 					"value": "cross-origin"
 				}
 			]
+		},
+		{
+			"source": "/(src(/.*)?|tutorial/lib(/.*)?|tutorial/types\\.ts|tutorial/web3-provider\\.ts|package\\.json|tsconfig\\.json|vite\\.config\\.ts|\\.gitignore)",
+			"headers": [
+				{
+					"key": "X-Robots-Tag",
+					"value": "noindex, nofollow, noarchive"
+				}
+			]
+		}
+	],
+	"redirects": [
+		{
+			"source": "/tutorial/getting-started-order",
+			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"permanent": true
+		},
+		{
+			"source": "/tutorial/create-pre-signed-order",
+			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"permanent": true
+		},
+		{
+			"source": "/tutorial/create-order-app-data",
+			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"permanent": true
+		},
+		{
+			"source": "/tutorial/create-eth-flow",
+			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"permanent": true
+		},
+		{
+			"source": "/tutorial/simple-app-data",
+			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"permanent": true
+		},
+		{
+			"source": "/tutorial/cancel-eth-flow",
+			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"permanent": true
+		},
+		{
+			"source": "/tutorial/approve-sell-token-order",
+			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"permanent": true
+		},
+		{
+			"source": "/tutorial/orderbook-upload-app-data",
+			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"permanent": true
+		},
+		{
+			"source": "/tutorial/view-app-data",
+			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"permanent": true
+		},
+		{
+			"source": "/tutorial/sign-order",
+			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"permanent": true
+		},
+		{
+			"source": "/tutorial/cancel-pre-signed-order",
+			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"permanent": true
 		}
 	]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
 	"$schema": "https://openapi.vercel.sh/vercel.json",
 	"headers": [
 		{
-			"source": "_app/immutable/workers/(.*)",
+			"source": "/_app/immutable/workers/:path*",
 			"headers": [
 				{
 					"key": "cross-origin-opener-policy",
@@ -19,7 +19,88 @@
 			]
 		},
 		{
-			"source": "/(src(/.*)?|tutorial/lib(/.*)?|tutorial/types\\.ts|tutorial/web3-provider\\.ts|package\\.json|tsconfig\\.json|vite\\.config\\.ts|\\.gitignore)",
+			"source": "/src",
+			"headers": [
+				{
+					"key": "X-Robots-Tag",
+					"value": "noindex, nofollow, noarchive"
+				}
+			]
+		},
+		{
+			"source": "/src/:path*",
+			"headers": [
+				{
+					"key": "X-Robots-Tag",
+					"value": "noindex, nofollow, noarchive"
+				}
+			]
+		},
+		{
+			"source": "/tutorial/lib",
+			"headers": [
+				{
+					"key": "X-Robots-Tag",
+					"value": "noindex, nofollow, noarchive"
+				}
+			]
+		},
+		{
+			"source": "/tutorial/lib/:path*",
+			"headers": [
+				{
+					"key": "X-Robots-Tag",
+					"value": "noindex, nofollow, noarchive"
+				}
+			]
+		},
+		{
+			"source": "/tutorial/types.ts",
+			"headers": [
+				{
+					"key": "X-Robots-Tag",
+					"value": "noindex, nofollow, noarchive"
+				}
+			]
+		},
+		{
+			"source": "/tutorial/web3-provider.ts",
+			"headers": [
+				{
+					"key": "X-Robots-Tag",
+					"value": "noindex, nofollow, noarchive"
+				}
+			]
+		},
+		{
+			"source": "/package.json",
+			"headers": [
+				{
+					"key": "X-Robots-Tag",
+					"value": "noindex, nofollow, noarchive"
+				}
+			]
+		},
+		{
+			"source": "/tsconfig.json",
+			"headers": [
+				{
+					"key": "X-Robots-Tag",
+					"value": "noindex, nofollow, noarchive"
+				}
+			]
+		},
+		{
+			"source": "/vite.config.ts",
+			"headers": [
+				{
+					"key": "X-Robots-Tag",
+					"value": "noindex, nofollow, noarchive"
+				}
+			]
+		},
+		{
+			"source": "/.gitignore",
 			"headers": [
 				{
 					"key": "X-Robots-Tag",

--- a/vercel.json
+++ b/vercel.json
@@ -112,57 +112,57 @@
 	"redirects": [
 		{
 			"source": "/tutorial/getting-started-order",
-			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"destination": "/tutorial/getting-started",
 			"permanent": true
 		},
 		{
 			"source": "/tutorial/create-pre-signed-order",
-			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"destination": "/tutorial/getting-started",
 			"permanent": true
 		},
 		{
 			"source": "/tutorial/create-order-app-data",
-			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"destination": "/tutorial/getting-started",
 			"permanent": true
 		},
 		{
 			"source": "/tutorial/create-eth-flow",
-			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"destination": "/tutorial/getting-started",
 			"permanent": true
 		},
 		{
 			"source": "/tutorial/simple-app-data",
-			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"destination": "/tutorial/getting-started",
 			"permanent": true
 		},
 		{
 			"source": "/tutorial/cancel-eth-flow",
-			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"destination": "/tutorial/cancel-on-chain-order",
 			"permanent": true
 		},
 		{
 			"source": "/tutorial/approve-sell-token-order",
-			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"destination": "/tutorial/approve-cow-protocol",
 			"permanent": true
 		},
 		{
 			"source": "/tutorial/orderbook-upload-app-data",
-			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"destination": "/tutorial/getting-started",
 			"permanent": true
 		},
 		{
 			"source": "/tutorial/view-app-data",
-			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"destination": "/tutorial/getting-started",
 			"permanent": true
 		},
 		{
 			"source": "/tutorial/sign-order",
-			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"destination": "/tutorial/submit-order",
 			"permanent": true
 		},
 		{
 			"source": "/tutorial/cancel-pre-signed-order",
-			"destination": "https://docs.cow.fi/cow-protocol/tutorials/building",
+			"destination": "/tutorial/getting-started",
 			"permanent": true
 		}
 	]


### PR DESCRIPTION
# Description

  Update learn.cow.fi Vercel routing to redirect legacy tutorial slugs to current Learn routes (root or closest equivalent) to eliminate 404s.

  Note: beta.learn.cow.fi is already redirected at the Vercel domain level (308), so no host-based rule is included here.

  # Changes

  - [ ] Keep /_app/immutable/workers/* headers: COOP same-origin, COEP require-corp, CORP cross-origin
  - [ ] Add X-Robots-Tag: noindex, nofollow, noarchive for /(src(/.*)?|tutorial/lib(/.*)?|tutorial/types\.ts|tutorial/web3-provider\.ts|package\.json|tsconfig\.json|vite\.config\.ts|\.gitignore)
  - [ ] 301 redirect the 11 legacy tutorial paths to current Learn routes

  | Old URL | Current Status | Expected After Deploy | New destination URL |
  | --- | --- | --- | --- |
  | https://learn.cow.fi/tutorial/getting-started-order | 404 | 301 | https://learn.cow.fi/tutorial/getting-started |
  | https://learn.cow.fi/tutorial/create-pre-signed-order | 404 | 301 | https://learn.cow.fi/tutorial/getting-started |
  | https://learn.cow.fi/tutorial/create-order-app-data | 404 | 301 | https://learn.cow.fi/tutorial/getting-started |
  | https://learn.cow.fi/tutorial/create-eth-flow | 404 | 301 | https://learn.cow.fi/tutorial/getting-started |
  | https://learn.cow.fi/tutorial/simple-app-data | 404 | 301 | https://learn.cow.fi/tutorial/getting-started |
  | https://learn.cow.fi/tutorial/cancel-eth-flow | 404 | 301 | https://learn.cow.fi/tutorial/cancel-on-chain-order |
  | https://learn.cow.fi/tutorial/approve-sell-token-order | 404 | 301 | https://learn.cow.fi/tutorial/approve-cow-protocol |
  | https://learn.cow.fi/tutorial/orderbook-upload-app-data | 404 | 301 | https://learn.cow.fi/tutorial/getting-started |
  | https://learn.cow.fi/tutorial/view-app-data | 404 | 301 | https://learn.cow.fi/tutorial/getting-started |
  | https://learn.cow.fi/tutorial/sign-order | 404 | 301 | https://learn.cow.fi/tutorial/submit-order |
  | https://learn.cow.fi/tutorial/cancel-pre-signed-order | 404 | 301 | https://learn.cow.fi/tutorial/getting-started |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added permanent redirects that consolidate various tutorial paths to updated internal tutorial pages.
  * Added per-path headers to prevent search engines from indexing or archiving internal source and configuration content.
  * Updated deployment routing for worker assets to use a revised source pattern for improved asset handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->